### PR TITLE
Added String Value for the API to be used

### DIFF
--- a/AadhaarOfflineSDKClient/app/src/main/java/co/hyperverge/aadhaarofflinesdkclient/MainActivity.java
+++ b/AadhaarOfflineSDKClient/app/src/main/java/co/hyperverge/aadhaarofflinesdkclient/MainActivity.java
@@ -19,6 +19,7 @@ import co.hyperverge.offlinekyc.aadhaar.HVAadhaarOfflineManager;
 public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = MainActivity.class.getCanonicalName();
+    private static final String KYC_API = "https://hv-aadhaar-xml.hyperverge.co/v2.1/readAadhaarXml";
 
     private HVAadhaarOfflineManager.AadhaarOfflineStartCallback aadhaarOfflineStartCallback =
             new HVAadhaarOfflineManager.AadhaarOfflineStartCallback() {
@@ -91,7 +92,7 @@ public class MainActivity extends AppCompatActivity {
                 .shouldShowUploadToolBar(true)
                 .uploadToolbarTitle("Complete your KYC")
                 .showManualFileAttachButton(true)
-                .offlineKycApi("https://hv-aadhaar-xml.hyperverge.co/v2.1/readAadhaarXml")
+                .offlineKycApi(KYC_API)
                 .build();
     }
 }


### PR DESCRIPTION
## Description:

Fixes: #17.

Added a String Value which stores the API url and is used instead of hardcoding it. Also can be used at multiple places also since it is declared at the begining.