### PR TITLE
Updated Android Gradle plugin

### DIFF
--- a/AadhaarOfflineSDKClient/build.gradle
+++ b/AadhaarOfflineSDKClient/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## Description:

Fixes: #21.

Updated the Android Gradle plugin from version 3.6.1 to its latest version 4.2.0 to reduce the Gradle Sync errors faced.